### PR TITLE
modified static cursor to 2 , so that PDO ODBC works.  NOTE:  Might h…

### DIFF
--- a/src/OdbcConnection.cpp
+++ b/src/OdbcConnection.cpp
@@ -637,7 +637,7 @@ RETCODE OdbcConnection::sqlGetInfo(SQLUSMALLINT type, SQLPOINTER ptr, SQLSMALLIN
 
             case SQL_STATIC_CURSOR_ATTRIBUTES1:
             case SQL_STATIC_CURSOR_ATTRIBUTES2:
-                value = 0;
+                value = 2;
                 break;
 
             case SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1:


### PR DESCRIPTION
…ave issues with cursors,  although I have not seen it yet.

This change was made to get php-pdo-odbc to work.  That is the unixODBC driver had issues with nuodb odbc driver when SQL_STATIC_CURSOR_ATTRIBUTES2 was set to 0.   The unixODBC tried to wrap our driver with another one and then I was getting [access violation]. invalid function pointers.   After making this change the wrapper was not installed and all worked.

I honest don't know what a valid value would be here.   As I'm not familiar with the ODBC spec.